### PR TITLE
Update the instance type from t2 to t3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "ec2_instances" {
   name = "my-ec2-cluster"
 
   ami                    = "ami-0c5204531f799e0c6"
-  instance_type          = "t2.micro"
+  instance_type          = "t3.micro"
   vpc_security_group_ids = [module.vpc.default_security_group_id]
   subnet_id              = module.vpc.public_subnets[0]
 


### PR DESCRIPTION
Some customers will get an error because the instance type t2.micro is not supported. 

Changed this to t3.micro to be compatible again